### PR TITLE
fix: removes hash from ZeekMessages contract on Atlas

### DIFF
--- a/contracts/ZeekMessages.sol
+++ b/contracts/ZeekMessages.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 contract ZeekMessages {
-    bytes32[] private messages;
+    string[] private messages;
 
     // Event to acknowledge a new message
     event MessageReceived(string);
@@ -12,10 +12,8 @@ contract ZeekMessages {
         emit MessageReceived("Zeek welcomes you to zkSync!");
     }
 
-    // Function to send a "secret" message to Zeek
     function sendMessage(string memory _message) public {
-        bytes32 hashedMessage = keccak256(abi.encodePacked(_message));
-        messages.push(hashedMessage);
+        messages.push(_message);
 
         // Acknowledge the message receipt with Zeek's reply
         emit MessageReceived("ZK is the endgame - Message received!");


### PR DESCRIPTION
## Description
I was working through the zkSync documentation and noticed a discrepancy between the ZeekMessages contract example in the docs and the version in this repository.

## Changes
The documentation presents a version of the contract that stores messages directly as strings, while the current version in the repository hashes the messages before storing them.

To ensure consistency between the documentation and the codebase, I've updated the ZeekMessages contract in this PR to match the version presented in the documentation:

Modified messages storage from bytes32[] to string[] to store messages as plain text.
Removed the hashing step from the sendMessage function.
This change aligns the contract implementation with what users would expect based on the documentation.

I have tested this updated contract on the Atlas platform to confirm that it compiles and functions as expected.

Please let me know if you have any questions or require any further adjustments.

Thank you!